### PR TITLE
Switch to Docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Nick Satterly <nick.satterly@theguardian.com>
 
 RUN apt-get update && apt-get install -y git wget build-essential python python-setuptools python-pip python-dev libffi-dev nginx
 
-RUN pip install alerta-server
+RUN pip install alerta-server alerta
 RUN pip install gunicorn supervisor
 
 RUN wget -q -O - https://github.com/alerta/angular-alerta-webui/tarball/master | tar zxf -

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '2.1'
+services:
+  web:
+    build: .
+    ports:
+      - "80:80"
+    depends_on:
+      - db
+    environment:
+      - AUTH_REQUIRED=${AUTH_REQUIRED:-False}
+      - ADMIN_USERS=${ADMIN_USERS:-not-set}
+      - CUSTOMER_VIEWS=${CUSTOMER_VIEWS:-False}
+      - PROVIDER=${PROVIDER:-basic}
+      - CLIENT_ID=${CLIENT_ID}
+      - CLIENT_SECRET=${CLIENT_SECRET}
+      - ALLOWED_EMAIL_DOMAIN=${ALLOWED_EMAIL_DOMAIN:-*}
+      - ALLOWED_GITHUB_ORGS=${ALLOWED_GITHUB_ORGS:-*}
+      - GITLAB_URL=${GITLAB_URL:-not-set}
+      - ALLOWED_GITLAB_GROUPS=${ALLOWED_GITLAB_GROUPS:-*}
+      - PLUGINS=${PLUGINS:-reject}
+      - ORIGIN_BLACKLIST=${ORIGIN_BLACKLIST:-not-set}
+      - ALLOWED_ENVIRONMENTS=${ALLOWED_ENVIRONMENTS:-Production,Development}
+      - MONGO_URI=mongodb://db:27017/monitoring
+    restart: always
+  db:
+    image: mongo
+    volumes:
+      - ./mongodb:/data/db
+    restart: always


### PR DESCRIPTION
Using latest version of Docker Composer which supports version 2.1 compose files means you can use environment variables with default values.

Note that setting the MongoDB environment variable like so `MONGO_URI=mongodb://db:27017/monitoring` means no special handling is required in the `database.py` module in Alerta server for Docker, any more.