### PR TITLE
Replace gunicorn with uwsgi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+mongodb

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ MAINTAINER Nick Satterly <nick.satterly@theguardian.com>
 RUN apt-get update && apt-get install -y git wget build-essential python python-setuptools python-pip python-dev libffi-dev nginx
 
 RUN pip install --upgrade pip
+RUN pip install uwsgi supervisor
 RUN pip install alerta-server alerta
-RUN pip install gunicorn supervisor
 
 RUN wget -q -O - https://github.com/alerta/angular-alerta-webui/tarball/master | tar zxf -
 RUN mv alerta-angular-alerta-webui-*/app /app
@@ -29,6 +29,8 @@ ENV ALLOWED_ENVIRONMENTS Production,Development
 
 ADD config.js.sh /config.js.sh
 ADD alertad.conf.sh /alertad.conf.sh
+RUN echo "from alerta.app import app" >/wsgi.py
+ADD uwsgi.ini /uwsgi.ini
 ADD nginx.conf /nginx.conf
 ADD supervisord.conf /etc/supervisord.conf
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,8 +2,8 @@
 nodaemon=true
 loglevel=debug
 
-[program:gunicorn]
-command=gunicorn --chdir /var/lib alerta.app:app --bind unix:/app.sock --access-logfile - --error-logfile -
+[progream:uwsgi]
+command=/usr/local/bin/uwsgi --ini /uwsgi.ini
 
 [program:nginx]
 command=nginx -c /nginx.conf

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,0 +1,18 @@
+[uwsgi]
+chdir = /
+mount = /api=wsgi.py
+callable = app
+manage-script-name = true
+
+master = true
+processes = 5
+logger = syslog:alertad
+
+socket = /tmp/uwsgi.sock
+chmod-socket = 664
+uid = www-data
+gid = www-data
+vacuum = true
+
+die-on-term = true
+


### PR DESCRIPTION
Docker is now based on the tutorial at http://docs.alerta.io/en/latest/gettingstarted/tutorial-1-deploy-alerta.html#tutorial-1