### PR TITLE
Setting ipv6only for `listen [::]:80` setting in nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -34,7 +34,7 @@ http {
 
         server {
                 listen 80 default_server;
-                listen [::]:80 default_server;
+                listen [::]:80 ipv6only=on default_server;
 
                 access_log /dev/stdout main;
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -33,7 +33,7 @@ http {
         '"\$http_user_agent"' ;
 
         server {
-                listen [::]:80 default_server;
+                listen [::]:80 ipv6only=off default_server;
 
                 access_log /dev/stdout main;
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -33,8 +33,7 @@ http {
         '"\$http_user_agent"' ;
 
         server {
-                listen 80 default_server;
-                listen [::]:80 ipv6only=on default_server;
+                listen [::]:80 default_server;
 
                 access_log /dev/stdout main;
 


### PR DESCRIPTION
This prevents the error `[emerg] 32#0: bind() to [::]:80 failed (98:
Address already in use)`, which occurs since the default configuration
provided listens on `80` and `[::]:80`, causing a conflict.