### PR TITLE
Split Plugins to Enable and To Install, Remove fefault PLUGINS value, Enclose bash variables into curly brackets and double quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ the `alerta-web` container:
     - password for ``MAIL_FROM`` email account
 
 `PLUGINS`
-    - list of plugins to automatically install and enable. (default: `reject`)
+    - list of plugins to enable.
+
+`INSTALL_PLUGINS`
+    - list of plugins to automatically install.
 
 Configuration Files
 -------------------

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,12 +2,12 @@
 
 set -ex
 
-ADMIN_USER=$(echo $ADMIN_USERS | cut -d, -f1)
-MONGO_ADDR=$(echo $MONGO_URI | sed -e 's/mongodb:\/\///')
+ADMIN_USER=$(echo "${ADMIN_USERS}" | cut -d, -f1)
+MONGO_ADDR=$(echo "${MONGO_URI}" | sed -e 's/mongodb:\/\///')
 
 # Generate web console config, if not supplied
-if [ ! -f "$ALERTA_WEB_CONF_FILE" ]; then
-  cat >$ALERTA_WEB_CONF_FILE << EOF
+if [ ! -f "${ALERTA_WEB_CONF_FILE}" ]; then
+  cat >"${ALERTA_WEB_CONF_FILE}" << EOF
 'use strict';
 
 angular.module('config', [])
@@ -21,14 +21,17 @@ EOF
 fi
 
 # Generate server config, if not supplied
-if [ ! -f "$ALERTA_SVR_CONF_FILE" ]; then
-  cat >$ALERTA_SVR_CONF_FILE << EOF
+if [ ! -f "${ALERTA_SVR_CONF_FILE}" ]; then
+  # Generate plugins list
+  PLUGINS_LIST=$( python -c "print('${PLUGINS}'.split(',') if '${PLUGINS}'.strip() else '[]')" )
+
+  cat >"${ALERTA_SVR_CONF_FILE}" << EOF
 DEBUG = True
 BASE_URL = '$BASE_URL'
 SECRET_KEY = '$(< /dev/urandom tr -dc A-Za-z0-9_\!\@\#\$\%\^\&\*\(\)-+= | head -c 32)'
 OAUTH2_CLIENT_ID = '$CLIENT_ID'
 OAUTH2_CLIENT_SECRET = '$CLIENT_SECRET'
-PLUGINS = $(python -c "print('${PLUGINS:-reject}'.split(','))")
+PLUGINS = $PLUGINS_LIST
 EOF
 else
   PLUGINS=$(python -c "exec(open('$ALERTA_SVR_CONF_FILE')); print(','.join(PLUGINS))")
@@ -37,13 +40,13 @@ fi
 # Generate API key for admin
 ADMIN_KEY=${ADMIN_KEY:-$(openssl rand -base64 32 | cut -c1-40)}
 EXPIRE_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z" -d +1year)
-/usr/bin/mongo $MONGO_ADDR --eval "db.keys.insert( \
+/usr/bin/mongo "${MONGO_ADDR}" --eval "db.keys.insert( \
     { \
         user:\"${ADMIN_USER:-internal}\", \
         key:\"${ADMIN_KEY}\", \
         scopes:[\"read\",\"write\",\"admin\"], \
         text:\"cron jobs\", \
-        expireTime: new Date(\"$EXPIRE_TIME\"), \
+        expireTime: new Date(\"${EXPIRE_TIME}\"), \
         count:0, \
         lastUsedTime: null \
     })"
@@ -56,13 +59,14 @@ key = ${KEY}
 EOF
 
 # Install plugins
-echo -n $PLUGINS | sed 's/,/\n/g' | grep -v reject | while read plugin
+echo -n "${INSTALL_PLUGINS}" | sed 's/,/\n/g;' | sed '/^$/d' | while read plugin
 do
+  echo "Installing plugin '${plugin}'"
   pip install git+https://github.com/alerta/alerta-contrib.git#subdirectory=plugins/$plugin
 done
 
 # Configure housekeeping and heartbeat alerts
-echo  "* * * * * root /usr/bin/mongo $MONGO_ADDR /housekeepingAlerts.js >>/var/log/cron.log 2>&1" >> /etc/cron.d/alerta
-echo  "* * * * * root ALERTA_CONF_FILE=$ALERTA_CONF_FILE /usr/local/bin/alerta heartbeats --alert >>/var/log/cron.log 2>&1" >> /etc/cron.d/alerta
+echo  "* * * * * root /usr/bin/mongo ${MONGO_ADDR} /housekeepingAlerts.js >>/var/log/cron.log 2>&1" >> /etc/cron.d/alerta
+echo  "* * * * * root ALERTA_CONF_FILE=${ALERTA_CONF_FILE} /usr/local/bin/alerta heartbeats --alert >>/var/log/cron.log 2>&1" >> /etc/cron.d/alerta
 
 exec "$@"


### PR DESCRIPTION
**PLUGINS** env variable should not have default value, reject is still a plugin, so if somebody would like to use *vanilla* alerta he would have to add some other plugin. So there is no way right now to have *vanilla* alerta.

Seperate Enabled plugins (**PLUGINS** variable) from Installed Plugins(**INSTALL_PLUGINS**), main reason is pretty simple, if you put another layer above original image (as is mentioned in https://github.com/alerta/docker-alerta#installing-plugins) with installed plugins, you cannot enable them other way than also binding configuration file with plugins, and then it would still try to install them.
This change simplify local plugin development under docker environment.

Enclosing bash variable into curly braces and double quotes:
This is best practice (for example see http://kvz.io/blog/2013/11/21/bash-best-practices/)