### PR TITLE
Set files to root group ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ COPY uwsgi.ini /app/uwsgi.ini
 COPY nginx.conf /app/nginx.conf
 RUN setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx
 
-RUN chown -R 1001:1001 /app /venv /web
+RUN chgrp -R 0 /app /venv /web && \
+    chmod -R g=u /app /venv /web
 USER 1001
 
 ENV ALERTA_SVR_CONF_FILE /app/alertad.conf


### PR DESCRIPTION
Found a working example...
```
### Setup user for build execution and application runtime
ENV APP_ROOT=/opt/app-root
ENV PATH=${APP_ROOT}/bin:${PATH} HOME=${APP_ROOT}
COPY bin/ ${APP_ROOT}/bin/
RUN chmod -R u+x ${APP_ROOT}/bin && \
    chgrp -R 0 ${APP_ROOT} && \
    chmod -R g=u ${APP_ROOT} /etc/passwd

### Containers should NOT run as root as a good practice
USER 10001
WORKDIR ${APP_ROOT}
```
https://github.com/RHsyseng/container-rhel-examples/blob/master/starter-arbitrary-uid/Dockerfile.centos7