### PR TITLE
Fix alerta client config missing when not create admin user

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -43,6 +43,11 @@ if [ ! -f "${RUN_ONCE}" ]; then
 endpoint = http://localhost:8080${BASE_URL}
 key = ${API_KEY}
 EOF
+  else
+    cat >${ALERTA_CONF_FILE} << EOF
+[DEFAULT]
+endpoint = http://localhost:8080${BASE_URL}
+EOF
   fi
 
   # Install plugins


### PR DESCRIPTION
When not config alerta cli config file, execute CLI (docker exec alerta-web alerta query) will output error message like this:

    Traceback (most recent call last):
        File "/venv/bin/alerta", line 11, in <module>
            sys.exit(cli())
        File "/venv/lib/python3.6/site-packages/click/core.py", line 722, in __call__
            return self.main(*args, **kwargs)
        File "/venv/lib/python3.6/site-packages/click/core.py", line 697, in main
            rv = self.invoke(ctx)
        File "/venv/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
            return _process_result(sub_ctx.command.invoke(sub_ctx))
        File "/venv/lib/python3.6/site-packages/click/core.py", line 895, in invoke
            return ctx.invoke(self.callback, **ctx.params)
        File "/venv/lib/python3.6/site-packages/click/core.py", line 535, in invoke
            return callback(*args, **kwargs)
        File "/venv/lib/python3.6/site-packages/click/decorators.py", line 27, in new_func
           return f(get_current_context().obj, *args, **kwargs)
       File "/venv/lib/python3.6/site-packages/alertaclient/commands/cmd_query.py", line 38, in cli
          r = client.http.get('/alerts', query)
       File "/venv/lib/python3.6/site-packages/alertaclient/api.py", line 319, in get
          return self._handle_error(response)
       File "/venv/lib/python3.6/site-packages/alertaclient/api.py", line 351, in _handle_error
          resp = response.json()
       File "/venv/lib/python3.6/site-packages/requests/models.py", line 892, in json
          return complexjson.loads(self.text, **kwargs)
       File "/usr/local/lib/python3.6/json/__init__.py", line 354, in loads
          return _default_decoder.decode(s)
       File "/usr/local/lib/python3.6/json/decoder.py", line 339, in decode
          obj, end = self.raw_decode(s, idx=_w(s, 0).end())
       File "/usr/local/lib/python3.6/json/decoder.py", line 357, in raw_decode
          raise JSONDecodeError("Expecting value", s, err.value) from None
    json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)