### PR TITLE
Separate images for backend and frontend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.6.5
+ENV PYTHONUNBUFFERED 1
+
+ARG VERSION
+
+RUN apt-get update && apt-get install -y \
+    mongodb-clients \
+    postgresql-client \
+    gettext
+
+RUN pip install uwsgi alerta alerta-server==$VERSION
+
+WORKDIR /app
+
+COPY wsgi.py /app/wsgi.py
+COPY uwsgi.ini.template /app/uwsgi.ini.template
+
+ENV ALERTA_SVR_CONF_FILE /app/alertad.conf
+ENV ALERTA_CONF_FILE /app/alerta.conf
+ENV ALERTA_WEB_CONF_FILE /web/config.js
+
+ENV BASE_URL /
+ENV INSTALL_PLUGINS ""
+
+EXPOSE 8080
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["uwsgi", "--ini", "/app/uwsgi.ini"]

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -x
+
+RUN_ONCE=/app/.run_once
+
+# Generate server config, if not supplied
+if [ ! -f "${ALERTA_SVR_CONF_FILE}" ]; then
+  cat >"${ALERTA_SVR_CONF_FILE}" << EOF
+SECRET_KEY = '$(< /dev/urandom tr -dc A-Za-z0-9_\!\@\#\$\%\^\&\*\(\)-+= | head -c 32)'
+EOF
+fi
+
+if [ ! -f "${RUN_ONCE}" ]; then
+  # Init admin users and API Keys
+  if [ -n "${ADMIN_USERS}" ]; then
+    alertad user --password ${ADMIN_PASSWORD:-alerta} --all
+    alertad key --all
+  fi
+
+  # Generate alerta CLI config
+  API_KEY=`alertad keys 2>/dev/null | head -1 | cut -d" " -f1`
+  if [ -n "${API_KEY}" ]; then
+    cat >${ALERTA_CONF_FILE} << EOF
+[DEFAULT]
+endpoint = http://localhost:8080
+key = ${API_KEY}
+EOF
+  fi
+
+  # Install plugins
+  IFS=","
+  for plugin in ${INSTALL_PLUGINS}
+  do
+    echo "Installing plugin '${plugin}'"
+    pip install git+https://github.com/alerta/alerta-contrib.git#subdirectory=plugins/$plugin
+  done
+  touch ${RUN_ONCE}
+fi
+
+envsubst < /app/uwsgi.ini.template > /app/uwsgi.ini
+
+exec "$@"

--- a/backend/uwsgi.ini.template
+++ b/backend/uwsgi.ini.template
@@ -1,0 +1,16 @@
+[uwsgi]
+chdir = /
+mount = ${BASE_URL}=/app/wsgi.py
+callable = app
+manage-script-name = true
+
+master = true
+processes = 5
+
+http-socket = :8080
+chmod-socket = 664
+uid = alerta
+gid = alerta
+vacuum = true
+
+die-on-term = true

--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -1,0 +1,5 @@
+
+try:
+    from alerta import app  # alerta >= 5.0
+except ImportError:
+    from alerta.app import app  # alerta < 5.0

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,27 @@
+FROM nginx:1.13
+
+ADD https://github.com/alerta/angular-alerta-webui/archive/master.tar.gz /tmp/web.tar.gz
+RUN tar zxvf /tmp/web.tar.gz -C /tmp && \
+    rm -rf /usr/share/nginx/html && \
+    mv /tmp/angular-alerta-webui-master/app /usr/share/nginx/html && \
+    mv /usr/share/nginx/html/config.js /usr/share/nginx/html/config.js.orig
+
+
+ENV ALERTA_API_SERVER '"http://"+window.location.hostname+":8080"'
+ENV AUTH_PROVIDER basic
+ENV CLIENT_ID "INSERT-CLIENT-ID-HERE"
+ENV GITHUB_URL ""
+ENV GITLAB_URL "https://gitlab.com"
+ENV KEYCLOAK_URL "https://keycloak.example.org"
+ENV KEYCLOAK_REALM "master"
+ENV PINGFEDERATE_URL "https://pingfederate.example.org"
+ENV COLORS {}
+ENV SEVERITY {}
+ENV AUDIO {}
+ENV TRACKING_ID ""
+
+COPY config.js.template /usr/share/nginx/html/config.js.template
+COPY alerta-frontend-entrypoint.sh /alerta-frontend-entrypoint.sh
+
+ENTRYPOINT ["/alerta-frontend-entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/alerta-frontend-entrypoint.sh
+++ b/frontend/alerta-frontend-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if ! echo -n "${ALERTA_API_SERVER}" | grep -q '^".*"$'; then
+  ALERTA_API_SERVER="\"${ALERTA_API_SERVER}\""
+fi
+
+envsubst < /usr/share/nginx/html/config.js.template > /usr/share/nginx/html/config.js
+
+exec "$@"

--- a/frontend/config.js.template
+++ b/frontend/config.js.template
@@ -1,0 +1,17 @@
+'use strict';
+
+angular.module('config', [])
+  .constant('config', {
+    'endpoint'        : ${ALERTA_API_SERVER},
+    'provider'        : "${AUTH_PROVIDER}", // google, github, gitlab, keycloak, pingfederate, saml2 or basic
+    'client_id'       : "${CLIENT_ID}",
+    'github_url'      : "${GITHUB_URL}",  // replace with your enterprise github server
+    'gitlab_url'      : "${GITLAB_URL}",  // replace with your gitlab server
+    'keycloak_url'    : "${KEYCLOAK_URL}",  // replace with your keycloak server
+    'keycloak_realm'  : "${KEYCLOAK_REALM}",  // replace with your keycloak realm
+    'pingfederate_url': "${PINGFEDERATE_URL}", // replace with your pingfederate server
+    'colors'          : ${COLORS}, // use default colors
+    'severity'        : ${SEVERITY}, // use default severity codes
+    'audio'           : ${AUDIO}, // no audio
+    'tracking_id'     : "${TRACKING_ID}"  // Google Analytics tracking ID eg. UA-NNNNNN-N
+  });


### PR DESCRIPTION
Hi,

recently we have deployed alerta in our company and we have a pretty high load, so we have decided to use alerta in HA. Sadly we have found out that alerta runs as `All in One` solution within docker container,
which is a bit inappropriate for docker orchestration such as kubernetes. Kubernetes allows to define liveness / readiness probes which are checking if container is alive / responding to requests. Using standard alerta image led to frontend being inaccessible all the time as the container were getting killed and recreated.

Because of this we splited  the image into two, one for frontend and one for backend. This allows us to have lower number of frontends (in our case 2) and scale only backends dynamically based on currrent load / requirements.

So this proposal is primarily for docker orchestration services but also may bring a bit more elasticity when using basic docker with some load balancer in front of it