### PR TITLE
Apply BASE_URL to web console URL also

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+
+VCS_REF=$(shell git rev-parse --short HEAD)
+BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+VERSION:=$(shell cat VERSION)
+
+.PHONY: version
+
+build:
+	docker-compose -f docker-compose.yml -f docker-compose.mongo.yml build \
+	--build-arg VCS_REF=$(VCS_REF) \
+	--build-arg BUILD_DATE=$(BUILD_DATE) \
+	--build-arg VERSION=$(VERSION)
+
+up:
+	docker-compose -f docker-compose.yml -f docker-compose.mongo.yml up
+
+down:
+	docker-compose -f docker-compose.yml -f docker-compose.mongo.yml down
+
+clean:
+	docker-compose -f docker-compose.yml -f docker-compose.mongo.yml rm
+
+version:
+	@docker-compose version
+	@echo "alerta version $(VERSION)"

--- a/docker-compose.mongo.yml
+++ b/docker-compose.mongo.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.2'
 services:
   web:
     environment:
@@ -8,4 +8,3 @@ services:
     volumes:
       - ./mongodb:/data/db
     restart: always
-  

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.2'
 services:
   web:
     environment:
@@ -12,4 +12,3 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     restart: always
-  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.2'
 services:
   web:
     build: .
@@ -12,7 +12,7 @@ services:
       - db
     environment:
       - DEBUG=1  # remove this line to turn DEBUG off
-      - BASE_URL=/api/v5
+      - BASE_URL=/alerta/api  # => web_url=/alerta
       - AUTH_REQUIRED=True
       - ADMIN_USERS=admin@alerta.io,devops@alerta.io
       # - ADMIN_USERS=admin@alerta.io
@@ -20,4 +20,3 @@ services:
       - PLUGINS=reject,blackout,normalise,enhance
       - INSTALL_PLUGINS=normalise,enhance
     restart: always
-  

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,6 +29,10 @@ if [ ! -f "${RUN_ONCE}" ]; then
   sed -i 's@!BASE_URL!@'"$BASE_URL"'@' /app/nginx.conf
   sed -i 's@!BASE_URL!@'"$BASE_URL"'@' /app/supervisord.conf
 
+  # Set Web URL
+  WEB_URL=${BASE_URL%/api}
+  sed -i 's@!WEB_URL!@'"${WEB_URL:=/}"'@' /app/nginx.conf
+
   # Init admin users and API Keys
   if [ -n "${ADMIN_USERS}" ]; then
     alertad user --password ${ADMIN_PASSWORD:-alerta} --all

--- a/nginx.conf
+++ b/nginx.conf
@@ -42,8 +42,8 @@ http {
                         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 }
 
-                location / {
-                        root /web;
+                location !WEB_URL! {
+                        alias /web/;
                 }
         }
 }


### PR DESCRIPTION
The web UI will now be served from the same path as the `BASE_URL` minus the `/api`. For example, if `BASE_URL=/alerta/api` then the Alert web UI will be available at `/alerta`.

Fixes #61 