### PR TITLE
Add Alerta group to the dockerfile

### DIFF
--- a/contrib/kubernetes/backend/Dockerfile
+++ b/contrib/kubernetes/backend/Dockerfile
@@ -12,6 +12,12 @@ RUN pip install uwsgi alerta alerta-server==$VERSION
 
 WORKDIR /app
 
+RUN chgrp -R 0 /app && \
+    chmod -R g=u /app && \
+    useradd -u 1001 -g 0 alerta
+
+USER 1001
+
 COPY wsgi.py /app/wsgi.py
 COPY uwsgi.ini.template /app/uwsgi.ini.template
 


### PR DESCRIPTION
The .ini references a group that doesn't exist (alerta) - need to add to the dockerfile otherwise it will error out with:

```
+ RUN_ONCE=/app/.run_once
+ '[' '!' -f /app/alertad.conf ']'
+ cat
++ tr -dc 'A-Za-z0-9_!@#$%^&*()-+='
++ head -c 32
+ '[' '!' -f /app/.run_once ']'
+ '[' -n '' ']'
++ cut '-d ' -f1
++ alertad keys
++ head -1
+ API_KEY=
+ '[' -n '' ']'
+ IFS=,
+ touch /app/.run_once
+ envsubst
+ exec uwsgi --ini /app/uwsgi.ini
[uWSGI] getting INI configuration from /app/uwsgi.ini
*** Starting uWSGI 2.0.17.1 (64bit) on [Thu Jul 12 11:40:10 2018] ***
compiled with version: 6.3.0 20170516 on 12 July 2018 10:26:34
os: Linux-4.14.22+ #1 SMP Thu May 10 17:54:42 PDT 2018
nodename: alerta-backend-6879fc85f7-mblsc
machine: x86_64
clock source: unix
pcre jit disabled
detected number of CPU cores: 4
current working directory: /app
detected binary path: /usr/local/bin/uwsgi
group alerta not found.
```