### PR TITLE
Double the uwsgi request header buffer size

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -8,6 +8,7 @@ master = true
 processes = 5
 
 socket = /tmp/uwsgi.sock
+buffer-size = 8192
 chmod-socket = 664
 uid = alerta
 gid = alerta


### PR DESCRIPTION
>By default uWSGI allocates a very small buffer (4096 bytes) for the headers of each request. If you start receiving “invalid request block size” in your logs, it could mean you need a bigger buffer. Increase it (up to 65535) with the buffer-size option.

https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html

Fixes https://github.com/alerta/alerta/issues/636