### PR TITLE
Set web UI subpath from base URL if provided

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,19 +19,19 @@ help:
 	@echo ""
 
 build:
-	docker-compose -f docker-compose.yml -f docker-compose.mongo.yml build \
+	docker-compose -f docker-compose.simple.yml build \
 	--build-arg VCS_REF=$(VCS_REF) \
 	--build-arg BUILD_DATE=$(BUILD_DATE) \
 	--build-arg VERSION=$(VERSION)
 
 up:
-	docker-compose -f docker-compose.yml -f docker-compose.mongo.yml up
+	docker-compose -f docker-compose.simple.yml up
 
 down:
-	docker-compose -f docker-compose.yml -f docker-compose.mongo.yml down
+	docker-compose -f docker-compose.simple.yml down
 
 clean:
-	docker-compose -f docker-compose.yml -f docker-compose.mongo.yml rm
+	docker-compose -f docker-compose.simple.yml rm
 
 version:
 	@docker-compose version

--- a/config.json.template
+++ b/config.json.template
@@ -1,1 +1,1 @@
-{"endpoint": "${BASE_URL}"}
+{"endpoint": "${BASE_URL}", "base_path": "${WEB_PATH}"}

--- a/docker-compose.simple.yml
+++ b/docker-compose.simple.yml
@@ -1,17 +1,20 @@
 version: '3.1'
 services:
   web:
+    build: .
     image: alerta/alerta-web
-    # build: .
+    # volumes:
+      # - $PWD/config/config.json:/web/config.json
     ports:
       - 8080:8080
     depends_on:
       - db
     environment:
       - DEBUG=1  # remove this line to turn DEBUG off
+      - BASE_URL=/alerta2/api
       - DATABASE_URL=postgres://postgres:postgres@db:5432/monitoring
-      - AUTH_REQUIRED=True
-      - ADMIN_USERS=admin@alerta.io,devops@alerta.io
+      # - AUTH_REQUIRED=True
+      # - ADMIN_USERS=admin@alerta.io,devops@alerta.io
       - PLUGINS=reject,blackout,normalise,enhance
     restart: always
   db:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+export BASE_PATH=$(echo "/"${BASE_URL#*//*/} | tr -s /)
+export WEB_PATH=$(echo ${BASE_PATH%/api}"/" | tr -s /)
+
 # Generate web console config, if not supplied
 if [ ! -f "${ALERTA_WEB_CONF_FILE}" ]; then
   envsubst < /web/config.json.template > "${ALERTA_WEB_CONF_FILE}"
@@ -18,14 +21,14 @@ RUN_ONCE=/app/.run_once
 if [ ! -f "${RUN_ONCE}" ]; then
   touch ${RUN_ONCE}
   # Set base path
-  BASE_PATH=$(echo "/"${BASE_URL#*//*/} | tr -s /)
   sed -i 's@!BASE_PATH!@'"${BASE_PATH}"'@' /app/uwsgi.ini
   sed -i 's@!BASE_PATH!@'"${BASE_PATH}"'@' /app/nginx.conf
   sed -i 's@!BASE_PATH!@'"${BASE_PATH}"'@' /app/supervisord.conf
 
   # Set Web URL
-  WEB_PATH=${BASE_PATH%/api}
-  sed -i 's@!WEB_PATH!@'"${WEB_PATH:=/}"'@' /app/nginx.conf
+  sed -i 's@!WEB_PATH!@'"${WEB_PATH}"'@' /app/nginx.conf
+  sed -i 's@href=/@href='"${WEB_PATH}"'@g' /web/index.html
+  sed -i 's@src=/@src='"${WEB_PATH}"'@g' /web/index.html
 
   # Init admin users and API keys
   if [ -n "${ADMIN_USERS}" ]; then


### PR DESCRIPTION
Second attempt at fixing subpath support. See #131 

To deploy Alerta at a subpath set the `BASE_URL` environment variable:
```
BASE_URL=/alerta2/api
```
... this will deploy the Alerta web UI at `/alerta2/` subpath. 

**Note:** There are still issues with refreshing the browser when at a dynamic route (eg. `/alert/:id`) but that is a separate issue, I think, and not actually related to getting subpaths working.