### PR TITLE
Add example envoy proxy setup

### DIFF
--- a/examples/envoy/api/alertad.conf
+++ b/examples/envoy/api/alertad.conf
@@ -1,0 +1,3 @@
+BASE_URL = 'http://api.local.alerta.io:8000/alerta/api/'
+USE_PROXYFIX = True
+SECRET_KEY = 'supersecret'

--- a/examples/envoy/docker-compose.yaml
+++ b/examples/envoy/docker-compose.yaml
@@ -1,0 +1,58 @@
+version: '3.7'
+
+services:
+  front:
+    image: envoyproxy/envoy:v1.13.1
+    volumes:
+      - ./proxy/front-proxy.yaml:/etc/envoy/envoy.yaml
+    expose:
+      - "80"
+      - "8001"
+    ports:
+      - "8000:80"
+      - "8001:8001"
+    networks:
+      - envoymesh
+
+  webui:
+    build:
+      context: webui
+    networks:
+      envoymesh:
+        aliases:
+          - web
+
+  api:
+    image: alerta/alerta-web  # use API in "alerta-web" image
+    depends_on:
+      - db
+    volumes:
+      - ./api/alertad.conf:/app/alertad.conf
+    environment:
+      DEBUG: 1  # remove this line to turn DEBUG off
+      DATABASE_URL: postgres://postgres:postgres@db:5432/monitoring
+      AUTH_REQUIRED: True
+      ADMIN_USERS: admin@alerta.io,devops@alerta.io #default password: alerta
+      ADMIN_KEY: demo-key  # assigned to first user in ADMIN_USERS list
+      # PLUGINS: reject,blackout,normalise,enhance
+    networks:
+      envoymesh:
+        aliases:
+          - api
+
+  db:
+    image: postgres
+    volumes:
+      - ./pg-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: monitoring
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    networks:
+      envoymesh:
+        aliases:
+          - db
+    restart: always
+
+networks:
+  envoymesh: {}

--- a/examples/envoy/proxy/front-proxy.yaml
+++ b/examples/envoy/proxy/front-proxy.yaml
@@ -1,0 +1,56 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: backend
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/alerta/ui"
+                route:
+                  prefix_rewrite: "/"
+                  cluster: web
+              - match:
+                  prefix: "/alerta/api"
+                route:
+                  prefix_rewrite: "/api"
+                  cluster: api
+          http_filters:
+          - name: envoy.router
+            typed_config: {}
+  clusters:
+  - name: web
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+      - socket_address:
+          address: web
+          port_value: 80
+  - name: api
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    hosts:
+      - socket_address:
+          address: api
+          port_value: 8080
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/examples/envoy/webui/.env
+++ b/examples/envoy/webui/.env
@@ -1,0 +1,1 @@
+BASE_URL=/alerta/ui

--- a/examples/envoy/webui/Dockerfile
+++ b/examples/envoy/webui/Dockerfile
@@ -1,0 +1,18 @@
+# build stage
+FROM node:lts-alpine as build-stage
+
+RUN apk add --no-cache git
+WORKDIR /app
+ADD https://github.com/alerta/alerta-webui/archive/master.tar.gz /tmp/webui.tar.gz
+RUN tar zxvf /tmp/webui.tar.gz -C /app --strip-components=1
+RUN npm install
+COPY .env .
+RUN npm run build
+
+# production stage
+FROM nginx:stable-alpine as production-stage
+COPY --from=build-stage /app/dist /app
+COPY config.json /app/config.json
+COPY nginx.conf /etc/nginx/nginx.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/examples/envoy/webui/config.json
+++ b/examples/envoy/webui/config.json
@@ -1,0 +1,1 @@
+{"endpoint": "http://proxy.local.alerta.io:8000/alerta/api"}

--- a/examples/envoy/webui/nginx.conf
+++ b/examples/envoy/webui/nginx.conf
@@ -1,0 +1,30 @@
+user  nginx;
+worker_processes  1;
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+events {
+  worker_connections  1024;
+}
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log  /var/log/nginx/access.log  main;
+  sendfile        on;
+  keepalive_timeout  65;
+  server {
+    listen       80;
+    server_name  localhost;
+    location / {
+      root   /app;
+      index  index.html;
+      try_files $uri $uri/ /index.html;
+    }
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+      root   /usr/share/nginx/html;
+    }
+  }
+}


### PR DESCRIPTION
To reverse proxy Alerta using Envoy proxy set the following ...

Web `.env` file
-  **must have** `BASE_URL=/non/root/path/`
- **must** build alerta-web new container with site-specific `BASE_URL`

API `alertad.conf` file
- *recommended to set* `BASE_URL` of API endpoint but currently broken eg. `BASE_URL='http://foo.example.com/alerta/api'`
- *recommended to set* `USE_PROXYFIX=True` but not sure it does anything

Steps to run this example...
```
$ cd examples/envoy
$ docker-compose build
$ docker-compose up
```
browse to http://local.alerta.io:8000/alerta/ui
