### PR TITLE
update deprecated deployment api version from apps/v1beta2 to apps/v1

### DIFF
--- a/contrib/kubernetes/helm/alerta/templates/deployment.yaml
+++ b/contrib/kubernetes/helm/alerta/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "alerta.fullname" . }}


### PR DESCRIPTION
Kubernetes declared the apps/deployment definition starting with 1.16 as stable so the api version `apps/v1beta2` should be replaced  the new api version `apps/v1`.

This PR updates the deployment specification to use the new api version.