### PR TITLE
update alerta image and postgresql requirement to current versions

### DIFF
--- a/contrib/kubernetes/helm/alerta/Chart.yaml
+++ b/contrib/kubernetes/helm/alerta/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "6.0.0"
+appVersion: "7.5.1"
 description: A Helm chart for Kubernetes
 name: alerta
-version: 0.1.0
+version: 0.1.1

--- a/contrib/kubernetes/helm/alerta/requirements.yaml
+++ b/contrib/kubernetes/helm/alerta/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
-    version: ~5.1.0
+    version: ~8.6.0
     repository: https://kubernetes-charts.storage.googleapis.com
     condition: postgresql.enabled

--- a/contrib/kubernetes/helm/alerta/values.yaml
+++ b/contrib/kubernetes/helm/alerta/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: alerta/alerta-web
-  tag: 6.0.0
+  tag: 7.5.1
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
This PR will update the helm chart to the current version of alerta (7.5.1) and also updates the postgresql requirement to the current version of 8.6.0