### PR TITLE
Update postgres dependency to bitnami charts

### DIFF
--- a/contrib/kubernetes/helm/alerta/requirements.yaml
+++ b/contrib/kubernetes/helm/alerta/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
-    version: ~8.6.0
-    repository: https://kubernetes-charts.storage.googleapis.com
+    version: "8.9.*"
+    repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled


### PR DESCRIPTION
- official chart is depcrecated. Bitnami chart is recommended. Hence dependency is updated
- also K8s 1.16 needs api update: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ otherwise I got:
```
unable to recognize "alerta-kustomize": no matches for kind "Deployment" in version "apps/v1beta2"
unable to recognize "alerta-kustomize": no matches for kind "StatefulSet" in version "apps/v1beta2
```