### PR TITLE
Add probes initial delay cause of startup slowness

### DIFF
--- a/contrib/kubernetes/helm/alerta/templates/deployment.yaml
+++ b/contrib/kubernetes/helm/alerta/templates/deployment.yaml
@@ -57,10 +57,12 @@ spec:
             httpGet:
               path: /
               port: http
+            initialDelaySeconds: 300  
           readinessProbe:
             httpGet:
               path: /
               port: http
+            initialDelaySeconds: 300  
           volumeMounts:
             - name: alerta-config
               mountPath: /app/alertad.conf


### PR DESCRIPTION
- I have seem now some occurences where supervisor takes its time to bring up everything cleanly, especially when plugins are installed, etc.
- Therefore in Kubernetes its recommended to delay the start of checking health or readiness probes to give the app more time to come up
- `initialDelaySeconds` of `300` seconds fixes the issue