### PR TITLE
fix depcreation of extensions/v1beta1/Ingress

### DIFF
--- a/contrib/kubernetes/helm/alerta/templates/ingress.yaml
+++ b/contrib/kubernetes/helm/alerta/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "alerta.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
The kind `Ingress` of the API version `extensions/v1beta1` is deprecated.

`warning: extensions/v1beta1/Ingress is deprecated by networking/v1beta1/Ingress and not supported by Kubernetes v1.20+ clusters.`

This PR upgrades the ingress manifest to use the new API version.