### PR TITLE
Creating home directory for alerta user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 
 RUN chgrp -R 0 /app /venv /web && \
     chmod -R g=u /app /venv /web && \
-    useradd -u 1001 -g 0 alerta
+    useradd -u 1001 -g 0 -d /app alerta
 
 USER 1001
 


### PR DESCRIPTION
This is a minor fix to make `cd` command in the `alerta` container work, given that when the user is added in the `Dockerfile` it implicitly gets `/home/alerta` ad home directory, which does not exist.

```
▶ docker run -it alerta/alerta-web:8.0.2 bash
Unable to find image 'alerta/alerta-web:8.0.2' locally
8.0.2: Pulling from alerta/alerta-web
Digest: sha256:23f8ddd64e84f77b40a1c5a80977fdd2490bddb0310589836b78c36eb6b98fcc
Status: Downloaded newer image for alerta/alerta-web:8.0.2
# Create server configuration file.
# Create client configuration file.

Alerta init process complete; ready for start up.

alerta@1aba1124f58d:/$ cd
bash: cd: /home/alerta: No such file or directory
alerta@1aba1124f58d:/$
```