### PR TITLE
Added support for NodePort service type (Helm)

### DIFF
--- a/contrib/kubernetes/helm/alerta/templates/service.yaml
+++ b/contrib/kubernetes/helm/alerta/templates/service.yaml
@@ -14,6 +14,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+{{- if contains "NodePort" .Values.service.type }}
+      nodePort: {{ default "30080" .Values.service.nodeport }}
+{{- end}}
   selector:
     app: {{ include "alerta.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
Hello,

this PR add support for NodePort [1] service type to helm chart.

Example

```yaml
service:
  type: NodePort
  port: 8080
  nodeport: 30080
```

[1] https://kubernetes.io/docs/concepts/services-networking/service/#nodeport