### PR TITLE
Waiting for database readiness and PostgreSQL database creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN curl -fsSL https://www.mongodb.org/static/pgp/server-4.2.asc | apt-key add -
     python3-dev \
     supervisor \
     wget \
+    netcat \
     xmlsec1 && \
     apt-get -y clean && \
     apt-get -y autoremove && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -34,6 +34,18 @@ while ! nc -z $db_host $db_port; do
 done
 echo "Database is ready."
 
+# preparement actions for PostgreSQL database
+if [ "$db_proto" == "postgres" ]; then
+  # export variables for psql CLI-tool to connect to db automatically
+  export PGUSER=$db_username
+  export PGPASSWORD=$db_password
+  export PGHOST=$db_host
+  export PGPORT=$db_port
+
+  echo "Create PostgreSQL database if it's not exist."
+  createdb $db_name 2>&1 1>&/dev/null || true
+fi
+
 # Generate minimal server config, if not supplied
 if [ ! -f "${ALERTA_SVR_CONF_FILE}" ]; then
   echo "# Create server configuration file."


### PR DESCRIPTION
When we start Alerta stack it would be better to wait for database TCP port readiness as it could run after Alerta services which will bring errors with writing to not-yet-started database.
Also shared PostgreSQL used with other services besides Alerta, doesn't automatically create database for Alerta, so in this PR entrypoint creates database for Alerta before starting services.