### PR TITLE
Make supervisord log level configurable via env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,7 @@ USER 1001
 ENV HEARTBEAT_SEVERITY major
 ENV HK_EXPIRED_DELETE_HRS 2
 ENV HK_INFO_DELETE_HRS 12
+ENV SUPERVISORD_LOG_LEVEL debug
 
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY supervisord.conf /app/supervisord.conf

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ API to ease deployment more generally:
 `PLUGINS`
     - list of plugins to enable.
 
+`SUPERVISORD_LOG_LEVEL`
+    - log level of the main stdout / stderr output of the container controlled by supervisord (default:`debug`)
+
 Configuration Files
 -------------------
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,7 +1,7 @@
 [supervisord]
 nodaemon=true
 logfile=/tmp/supervisord.log
-loglevel=debug
+loglevel=%(ENV_SUPERVISORD_LOG_LEVEL)s
 pidfile=/tmp/supervisord.pid
 
 [program:uwsgi]


### PR DESCRIPTION
The supervisord log level controls the containers log output regardless
of the DEBUG=0|1 flag or other nginx log level settings, thus should be
configurable.

IMO I'd set log level to warn by default to supress access logs which
is desired for most production deployments I suppose. That really depends
on the main use-case for this image though. If it's for development setups,
then of course debug is totally fine. Also debug won't brake existing
behavior.

DOCS: the docs need an update to indicate that this can be controlled
for docker containers. While we are at it I'd also add the other options
of hipervisord that can be controlled this way.