### PR TITLE
OpenShift Postgres settings

### DIFF
--- a/contrib/kubernetes/helm/alerta/values.yaml
+++ b/contrib/kubernetes/helm/alerta/values.yaml
@@ -91,3 +91,15 @@ postgresql:
   persistence:
     enabled: true
     size: 10Gi
+
+  # If deploying on OpenShift
+  # volumePermissions:
+  #   securityContext:
+  #     runAsUser: "auto"
+  # securityContext:
+  #  enabled: false
+  # containerSecurityContext:
+  #  enabled: false,
+  # shmVolume:
+  #  chmod:
+  #    enabled: false


### PR DESCRIPTION
To deploy Postgres on OpenShift that is dynamically assigning a uid
one can set these settings to the postgres helm chart.

https://github.com/bitnami/charts/tree/master/bitnami/postgresql/#differences-between-bitnami-postgresql-image-and-docker-official-image