### PR TITLE
apply security upgrades of base image on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
     build-essential \
     curl \


### PR DESCRIPTION
I would suggest applying security upgrades to the debian base image on build.
Let me know what you think.