### PR TITLE
bump postgresql helm chart version to 10.6.x

### DIFF
--- a/contrib/kubernetes/helm/alerta/requirements.yaml
+++ b/contrib/kubernetes/helm/alerta/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
-    version: "8.9.*"
+    version: "10.6.*"
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled


### PR DESCRIPTION
I am currently using a helm deployment with bitnami/postgresql `v10.6.1` without any problems.

If you are upgrading from `v8.9.x` you need to recreate the statefulset, as described here:

- [To 10.0.0](https://github.com/bitnami/charts/tree/master/bitnami/postgresql/#to-1000) (The step [To 9.0.0](https://github.com/bitnami/charts/tree/master/bitnami/postgresql/#to-900) is included in the [To 10.0.0](https://github.com/bitnami/charts/tree/master/bitnami/postgresql/#to-1000))

Do we need to adapt anything else to close https://github.com/alerta/docker-alerta/issues/257 ?