### PR TITLE
migrate ingress api version (v1.19+)

### DIFF
--- a/contrib/kubernetes/helm/alerta/templates/ingress.yaml
+++ b/contrib/kubernetes/helm/alerta/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "alerta.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -31,8 +31,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The current ingress API version in use will no longer be served in the next stable release `v1.22`.
Migration to the ingress version `networking.k8s.io/v1` as described here: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

I need to double check this change in another kubernetes environment. 