### PR TITLE
Add option to control supervisord log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,13 @@ The following environment variables are supported by the Alerta
 API to ease deployment more generally:
 
 `DEBUG`
-    - debug mode for increased logging. (eg. `DEBUG=1`)
+    - debug mode for increased logging. equivalent of setting `LOG_LEVEL=debug` (eg. `DEBUG=1`)
+
+`LOG_LEVEL`
+    - log level of Alerta application and nginx (default:`warn`)
+
+`SUPERVISORD_LOG_LEVEL`
+    - log level of supervisord, must be `debug` or lower to see appliation logs (default:`debug`)
 
 `SECRET_KEY`
     - a unique, randomly generated sequence of ASCII characters.

--- a/config/templates/app/supervisord.conf.j2
+++ b/config/templates/app/supervisord.conf.j2
@@ -1,11 +1,7 @@
 [supervisord]
 nodaemon=true
 logfile=/tmp/supervisord.log
-{%- if env.DEBUG %}
-loglevel=debug
-{%- else %}
-loglevel={{ env.LOG_LEVEL|lower or 'warn' }}
-{%- endif %}
+loglevel={{ env.SUPERVISORD_LOG_LEVEL|lower or 'debug' }}
 pidfile=/tmp/supervisord.pid
 
 [program:uwsgi]


### PR DESCRIPTION
Set the log level of the `supervisord` daemon. Default is `debug` so that new users of the container aren't confused by nothing being logged. Set to `info` or higher to suppress nginx/flask logging...

```
SUPERVISORD_LOG_LEVEL=info
```

Supercedes #308