### PR TITLE
Helm chart: handle multiline config values

### DIFF
--- a/contrib/kubernetes/helm/alerta/templates/configmap.yaml
+++ b/contrib/kubernetes/helm/alerta/templates/configmap.yaml
@@ -3,7 +3,7 @@ data:
   alertad.conf: |
     {{- if .Values.alertaConfig }}
     {{ range $key, $value := .Values.alertaConfig }}
-    {{ $key }} = {{ $value }}
+    {{ $key }} = {{ $value | nindent 4 | trim }}
     {{- end }}
     {{- end }}
     {{ if .Values.postgresql.enabled -}}


### PR DESCRIPTION
Some Alerta config values are typically multiline constructs, e.g. `SEVERITY_MAP` (see [docs](https://docs.alerta.io/configuration.html#severity-settings)). So far, using multiline values breaks the indentation of this ConfigMap.

This change adds indentation to all but the first line, so that multiline values are possible. It does not impact single-line values.

Example use:

```yaml
# excerpt of chart values

alertaConfig:
  SEVERITY_MAP: |
    {
      'security': 0,
      'critical': 1,
      'whatever': 10
    }
```

The resulting config is syntactically correct and matches the format used in the docs.