### PR TITLE
Add Helm variable for ingress class name.

### DIFF
--- a/contrib/kubernetes/helm/alerta/Chart.yaml
+++ b/contrib/kubernetes/helm/alerta/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.1.0"
+appVersion: "8.7.0"
 description: A Helm chart for Kubernetes
 name: alerta
-version: 0.3.0
+version: 0.4.0

--- a/contrib/kubernetes/helm/alerta/templates/deployment.yaml
+++ b/contrib/kubernetes/helm/alerta/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
               {{- if .Values.alertaAdminUsers }}

--- a/contrib/kubernetes/helm/alerta/templates/ingress.yaml
+++ b/contrib/kubernetes/helm/alerta/templates/ingress.yaml
@@ -15,6 +15,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/contrib/kubernetes/helm/alerta/values.yaml
+++ b/contrib/kubernetes/helm/alerta/values.yaml
@@ -6,7 +6,9 @@ replicaCount: 1
 
 image:
   repository: alerta/alerta-web
-  tag: 8.1.0
+  # Override the image tag to deploy by setting this variable.
+  # If no value is set, the chart's appVersion will be used.
+  tag: ""
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -21,6 +23,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  className: ""
   path: /
   hosts:
     - alerta.example.com


### PR DESCRIPTION
Add a Helm variable in chart to specify the class name of the ingress.  
Allow to be compliant with `ingress-nginx` `>=1.0.0`

I took the opportunity to bump the chart version and use application version by default as the tag of the pod image.