### PR TITLE
[helm-chart] changing postgresql chart version

### DIFF
--- a/contrib/kubernetes/helm/alerta/requirements.yaml
+++ b/contrib/kubernetes/helm/alerta/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
-    version: "10.6.*"
+    version: "10.16.2"
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled


### PR DESCRIPTION
**The following error receiving while installing via Helm**
`Error: can't get a valid version for repositories postgresql. Try changing the version constraint in Chart.yaml`

**What this PR does / why we need it:**
This PR is about a change of postgresql chart version (selected the latest version) from 10.x.x versions.