### PR TITLE
Update nginx example webui Dockerfile to fix build

### DIFF
--- a/examples/nginx/webui/Dockerfile
+++ b/examples/nginx/webui/Dockerfile
@@ -1,7 +1,6 @@
 # build stage
-FROM node:lts-alpine as build-stage
+FROM node:14-buster as build-stage
 
-RUN apk add --no-cache git
 WORKDIR /app
 ADD https://github.com/alerta/alerta-webui/archive/master.tar.gz /tmp/webui.tar.gz
 RUN tar zxvf /tmp/webui.tar.gz -C /app --strip-components=1


### PR DESCRIPTION
Docker build was failing due to incompatibilities with the referenced node:lts-alpine image, which seems to use node16.
Changed to use node:14-buster image, and removed alpine specific lines (apk add).