### PR TITLE
Fix nginx 413 error

### DIFF
--- a/config/templates/app/nginx.conf.j2
+++ b/config/templates/app/nginx.conf.j2
@@ -26,6 +26,7 @@ http {
 
         gzip on;
         gzip_disable "msie6";
+        client_max_body_size 100M;
 
         log_format main '$remote_addr - $remote_user [$time_local] '
                         '"$request" $status $body_bytes_sent '

--- a/config/templates/app/nginx.conf.j2
+++ b/config/templates/app/nginx.conf.j2
@@ -26,7 +26,9 @@ http {
 
         gzip on;
         gzip_disable "msie6";
-        client_max_body_size 100M;
+{%- if env.NGINX_MAX_BODY_SIZE %}
+        client_max_body_size {{ env.NGINX_MAX_BODY_SIZE }};
+{%- endif %}
 
         log_format main '$remote_addr - $remote_user [$time_local] '
                         '"$request" $status $body_bytes_sent '

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.1'
 services:
   web:
-    image: ntcnlgotz/alerta-web
+    image: alerta/alerta-web
     # volumes:
       # - $PWD/config/config.json:/web/config.json
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.1'
 services:
   web:
-    image: alerta/alerta-web
+    image: ntcnlgotz/alerta-web
     # volumes:
       # - $PWD/config/config.json:/web/config.json
     ports:
@@ -16,6 +16,7 @@ services:
       - ADMIN_PASSWORD=super-secret # default is "alerta"
       - ADMIN_KEY=demo-key  # assigned to first user in ADMIN_USERS
       - ADMIN_KEY_MAXAGE=500
+      # - NGINX_MAX_BODY_SIZE=42M  # allow larger alerts to be processed by alerta
       # - PLUGINS=remote_ip,reject,heartbeat,blackout,normalise,enhance
     restart: always
 


### PR DESCRIPTION
**Description**
When dealing with large alerts (>1M) NGINX would return a 413 error. This fixes that by allowing the end user to set the NGINX `client_max_body_size` via the environment variable `NGINX_MAX_BODY_SIZE`. NGINX defaults to 1M which was causing issues with large alerts.

Fixes #441

**Changes**
Include a brief summary of changes...
- added environment variable to nginx.conf.j2
- added sample configuration to docker-compose.yml (commented out by default)

**Checklist**
- [x] Pull request is limited to a single purpose
- [x] Code style/formatting is consistent
- [x] All existing tests are passing
- [x] Added new tests related to change
- [x] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

