### PR TITLE
fix: Fix entrypoint housekeeping api key scope format

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,9 +42,9 @@ if [ ! -f "${ALERTA_CONF_FILE}" ]; then
   # Add API key to client config, if required
   if [ "${AUTH_REQUIRED,,}" == "true" ]; then
     echo "# Auth enabled; add admin API key to client configuration."
-    HOUSEKEEPING_SCOPES="--scope \"read\" --scope \"write:alerts\" --scope \"admin:management\""
+    HOUSEKEEPING_SCOPES="--scope read --scope write:alerts --scope admin:management"
     if grep -qE 'CUSTOMER_VIEWS.*=.*True' ${ALERTA_SVR_CONF_FILE};then
-      HOUSEKEEPING_SCOPES="--scope \"admin:alerts\" ${HOUSEKEEPING_SCOPES}"
+      HOUSEKEEPING_SCOPES="--scope admin:alerts ${HOUSEKEEPING_SCOPES}"
     fi
     export API_KEY=$(alertad key \
     --username "${ADMIN_USER}" \


### PR DESCRIPTION
**Description**

I recently upgraded our setup to docker-web:9.0.1 and discovered that my previous commit on the entrypoint broke it and was generating a housekeeping api key with wrong scope (every scope was surrounded by double quotes).
This PR fixes my mistake

**Changes**

Remove the quotes from the scopes that were introduced in https://github.com/alerta/docker-alerta/commit/a584da59f43ac270dc18b5f72c0eb1029cf0e540. 

**Checklist**
- [x] Pull request is limited to a single purpose
- [x] Code style/formatting is consistent
- [x] All existing tests are passing
- [x] Added new tests related to change
- [x] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

