### PR TITLE
do not exit in case admin API key can not be created

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -33,7 +33,7 @@ if [ -n "${ADMIN_USERS}" ]; then
   # Create user-defined API key, if required
   if [ -n "${ADMIN_KEY}" ]; then
     echo "# Create user-defined admin API key."
-    alertad key --username "${ADMIN_USER}" --key "${ADMIN_KEY}" --duration "${MAXAGE}"
+    alertad key --username "${ADMIN_USER}" --key "${ADMIN_KEY}" --duration "${MAXAGE}" || true
   fi
 fi
 


### PR DESCRIPTION
**Description**
After a large number of API keys have been created in Alerta, the admin API key creation step in the entrypoint script may fail with a duplicate key error, preventing the container from starting up properly. Additionally, this issue might be related to the UI not displaying all API keys, despite their presence in the database.

_Example:_

```bash
$ alertad key --username "admin@example.com" --key "testing" --duration "315360000"
ERROR: duplicate key value violates unique constraint "keys_key_key"
DETAIL:  Key (key)=(testing) already exists.
```

Appending `|| true` to the `alertad` command resolves the issue, mirroring the adjustment made to another `alertad` command on line 29.

**Changes**
- added `|| true` to the respective part of the entrypoint script

**Checklist**
- [x] Pull request is limited to a single purpose
- [x] Code style/formatting is consistent
- [ ] All existing tests are passing
- [ ] Added new tests related to change
- [x] No unnecessary whitespace changes