### PR TITLE
fix: only push to DockerHub on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          push: true
+          push: ${{ github.event_name == 'push' }}
           build-args: |
             BUILD_DATE=${{ steps.meta.outputs.BUILD_DATE }}
             RELEASE=${{ steps.meta.outputs.RELEASE }}
@@ -95,6 +95,7 @@ jobs:
   manifest:
     name: Create Manifest
     needs: build
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- `workflow_dispatch` now builds only (no push to DockerHub)
- Manifest creation skipped on manual dispatch
- Tag pushes continue to build and publish as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)